### PR TITLE
[binance] fix missing control statements

### DIFF
--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
@@ -457,6 +457,7 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
               intervalMap.remove(klineInterval);
               return intervalMap;
             });
+        break;
       default:
         throw new IllegalArgumentException(
             "Subscription type not supported to unsubscribe from stream");


### PR DESCRIPTION
Added 'break' statement after KLINE case to prevent fall-through.